### PR TITLE
Add ASG for on demand instances

### DIFF
--- a/modules/imputation-server/outputs.tf
+++ b/modules/imputation-server/outputs.tf
@@ -34,18 +34,33 @@ output "emr_ec2_attributes" {
 }
 
 output "emr_instance_group_id" {
-  description = "The EMR Instance ID"
+  description = "The EMR (spot) Instance Group ID"
   value       = aws_emr_instance_group.task.id
 }
 
 output "emr_instance_group_name" {
-  description = "The name of the Instance Group"
+  description = "The name of the (spot) Instance Group"
   value       = aws_emr_instance_group.task.name
 }
 
 output "emr_instance_group_running_instance_count" {
-  description = "The number of instances currently running in this instance group"
+  description = "The number of (spot) instances currently running in this instance group"
   value       = aws_emr_instance_group.task.running_instance_count
+}
+
+output "emr_instance_group_ondemand_id" {
+  description = "The EMR (on demand) Instance ID"
+  value       = aws_emr_instance_group.task_ondemand.id
+}
+
+output "emr_instance_group_ondemand_name" {
+  description = "The name of the (on demand) Instance Group"
+  value       = aws_emr_instance_group.task_ondemand.name
+}
+
+output "emr_instance_group_ondemand_running_instance_count" {
+  description = "The number of (on demand) instances currently running in this instance group"
+  value       = aws_emr_instance_group.task_ondemand.running_instance_count
 }
 
 output "emr_log_uri" {

--- a/modules/imputation-server/variables.tf
+++ b/modules/imputation-server/variables.tf
@@ -188,14 +188,28 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "task_instance_count_max" {
-  description = "Max capacity for task instance ASG"
+# On demand instances are a fallback for spot, and should have fewer instances.
+variable "task_instance_ondemand_count_max" {
+  description = "Max capacity for task instance ASG (on demand)"
   default     = 50
   type        = number
 }
 
-variable "task_instance_count_min" {
-  description = "Min capacity for task instance ASG"
+variable "task_instance_ondemand_count_min" {
+  description = "Min capacity for task instance ASG (on demand)"
+  default     = 1
+  type        = number
+}
+
+# Spot instances are the preferred worker type and should usually have higher min/max values
+variable "task_instance_spot_count_max" {
+  description = "Max capacity for task instance ASG (spot)"
+  default     = 50
+  type        = number
+}
+
+variable "task_instance_spot_count_min" {
+  description = "Min capacity for task instance ASG (spot)"
   default     = 3
   type        = number
 }


### PR DESCRIPTION
## Purpose
Companion to https://github.com/statgen/terraform-imputationserver/pull/1
Add a permanent "on demand" ASG for EMR, reflecting an ASG that often has to be created manually after every deploy.

We previously only provisioned spot ASG, but these instances are sometimes totally unavailable. A permanent smaller ASG pool will prevent total queue blockage, and a less aggressive scaling policy will cause spot instances to be preferred.

Note: omitting bid price is how this new config allocates on demand instances. Mostly similar to the spot IG otherwise.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_instance_group

## Summary of changes and deployment notes
- Rename existing variables in code to reflect spot/on demand split 
  - Need to confirm that terraform does not treat variable names as a change requiring refactor commands, as long as values are the same
  -  This may require updating terraform cloud if custom values are entered for these variable names
- Add new input and output values for on demand ASG count
- Review whether output values are used anywhere. If so, update usages to reflect renames and/or new "on demand" outputs.
- Are there any additional safeguards for the situation where both spot and on demand both become available? ("Max workers across all instances")
  - We don't want to end up allocating 2x the cost intended under a period of high IS usage and high EMR availability.

## How to test this
Get terraform CLI working with remote state and review execution plan against dev environment.

Can we test modules updated on a dev branch without also affecting prod? How smart are these terraform magic module urls?